### PR TITLE
Update icon_taglist.lua

### DIFF
--- a/config/awesome/noodle/icon_taglist.lua
+++ b/config/awesome/noodle/icon_taglist.lua
@@ -65,9 +65,9 @@ local function update_widget()
     if s.tags[i] then
       tag_clients = s.tags[i]:clients()
     end
-    if s.tags[i] == s.selected_tag then
+    if s.tags[i] and s.tags[i].selected then
       tag_icons[i].image = beautiful.taglist_icons_focused[i]
-    elseif awful.tag.getproperty(s.tags[i], "urgent") then
+    elseif s.tags[i] and s.tags[i].urgent then
       tag_icons[i].image = beautiful.taglist_icons_urgent[i]
     elseif tag_clients and #tag_clients > 0 then
       tag_icons[i].image = beautiful.taglist_icons_occupied[i]


### PR DESCRIPTION
-removed use of deprecated function awful.tag.getproperty.
-check if the tag is selected, rather than checking if the tag matches the screen's selected_tag. This allows multiple tags to be selected (and use their selected icons correctly).