### PR TITLE
fixed wibars_toggle

### DIFF
--- a/config/awesome/keys.lua
+++ b/config/awesome/keys.lua
@@ -540,7 +540,7 @@ keys.globalkeys = gears.table.join(
     awful.key({ superkey }, "grave", function() sidebar.visible = not sidebar.visible end,
         {description = "show or hide sidebar", group = "awesome"}),
     -- Toggle wibar(s)
-    awful.key({ superkey, shiftkey }, "b", wibars_toggle,
+    awful.key({ superkey, shiftkey }, "b", function() wibars_toggle() end,
         {description = "show or hide wibar(s)", group = "awesome"}),
     -- Emacs (O for org mode)
     awful.key({ superkey }, "o", apps.org,


### PR DESCRIPTION
I tried to use the keybind to toggle the bar ```super + shift + b``` and it didn't work until I tweaked a little bit the file keys.lua, reading the code and how you implemented others keybindings. because I really dont have much Idea of lua.

I dont really know If this where a problem for others, feel free to dismiss the pull request :wink: 