### PR TITLE
Add comma to commented web_search_cmd

### DIFF
--- a/config/awesome/rc.lua
+++ b/config/awesome/rc.lua
@@ -86,7 +86,7 @@ user = {
 
     -- >> Web Search <<
     web_search_cmd = "xdg-open https://duckduckgo.com/?q=",
-    -- web_search_cmd = "xdg-open https://www.google.com/search?q="
+    -- web_search_cmd = "xdg-open https://www.google.com/search?q=",
 
     -- >> User profile <<
     profile_picture = os.getenv("HOME").."/.config/awesome/profile.png",


### PR DESCRIPTION
This way, if you uncomment it, it won't give an error about a missing comma.