### PR TITLE
Stick to english language when listening for pulseaudio events.

### DIFF
--- a/config/awesome/evil/volume.lua
+++ b/config/awesome/evil/volume.lua
@@ -37,7 +37,7 @@ emit_volume_info()
 -- Sleeps until pactl detects an event (volume up/down/toggle mute)
 local volume_script = [[
     bash -c "
-    pactl subscribe 2> /dev/null | grep --line-buffered \"Event 'change' on sink #\"
+    LANG=C pactl subscribe 2> /dev/null | grep --line-buffered \"Event 'change' on sink #\"
     "]]
 
 


### PR DESCRIPTION
For example in system with polish language configuration pactl subscribe outputs something like this
> Zdarzenie „zmień” w odpływ #0
> Zdarzenie „zmień” w źródło #0
> Zdarzenie „zmień” w źródło #1
> Zdarzenie „nowy” w klient #14
> Zdarzenie „zmień” w klient #14
> Zdarzenie „zmień” w odpływ #0
> Zdarzenie „zmień” w źródło #0
> Zdarzenie „nowy” w wyjście-źródła #4
