### PR TITLE
fixes missing uptime from  #155

### DIFF
--- a/config/awesome/elemental/dashboard/amarena.lua
+++ b/config/awesome/elemental/dashboard/amarena.lua
@@ -443,9 +443,9 @@ local icon_size = dpi(40)
 
 -- Uptime
 local uptime_text = wibox.widget.textbox()
-awful.widget.watch("uptime -p | sed 's/^...//'", 60, function(_, stdout)
-    -- Remove trailing whitespaces
-    local out = stdout:gsub('^%s*(.-)%s*$', '%1')
+awful.widget.watch("uptime -p", 60, function(_, stdout)
+    -- Remove trailing whitespaces and the "up" prefix
+    local out = stdout:gsub('^%s*up%s(.-)%s*$', '%1')
     uptime_text.text = out
 end)
 local uptime = wibox.widget {


### PR DESCRIPTION
awful.widget.watch only invokes a command and not an entire shell. The pipe here doesn't work so I moved the removal of the "up " string into the existing regex below.

(btw I love your awesome dotfiles, thank you for your work!)