### PR TITLE
Fixed The Issue of Screen Stuck (Powermenu)

### DIFF
--- a/config/eww/scripts/manage
+++ b/config/eww/scripts/manage
@@ -228,6 +228,7 @@ _hide() {
     _pre_hide "$widget_name"
     _mode_disable "$widget_name"
     eww update "${widget_name}"-visible=false
+    swaymsg -q mode default
     sleep "$(_get_revealer_duration_seconds "$widget_name")"
     _close "$widget_name"
     _post_hide "$widget_name"

--- a/config/sway/config
+++ b/config/sway/config
@@ -14,3 +14,9 @@ include ~/.config/sway/bugfix
 include @sysconfdir@/sway/config.d/*
 
 # vim:set ft=conf:
+
+
+mode "_powermenu" {
+    bindsym Escape mode "default"
+    # Add other powermenu keybindings here if needed
+}


### PR DESCRIPTION
Added an Escape keybinding to exit powermenu mode in your Sway config.
Powermenu always get resets Sway mode to default when closed.

